### PR TITLE
Fix flaky feature context integration tests

### DIFF
--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureSdkCoreTest.kt
@@ -240,10 +240,10 @@ class FeatureSdkCoreTest : MockServerTest() {
         testedFeatureSdkCore.registerFeature(stubFeature)
         val fakeKeyValues1 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "first_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeKeyValues2 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "second_${anAlphabeticalString()}" to anAlphabeticalString() }
         val expectedKeyValues = fakeKeyValues1 + fakeKeyValues2
 
         val updateAction = { newContext: Map<String, String> ->
@@ -276,10 +276,10 @@ class FeatureSdkCoreTest : MockServerTest() {
         testedFeatureSdkCore.registerFeature(stubFeature)
         val fakeKeyValues1 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "first_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeKeyValues2 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "second_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeModifiedValues = fakeKeyValues2.mapValues { (_, _) -> forge.anAlphabeticalString() }
         val expectedKeyValues = fakeKeyValues1 + fakeModifiedValues
 
@@ -323,10 +323,10 @@ class FeatureSdkCoreTest : MockServerTest() {
         testedFeatureSdkCore.registerFeature(stubFeature)
         val fakeKeyValues1 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "first_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeKeyValues2 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "second_${anAlphabeticalString()}" to anAlphabeticalString() }
         val expectedKeyValues = (fakeKeyValues1 + fakeKeyValues2).toMutableMap()
         val droppedKeyValues = expectedKeyValues.removeRandomEntries(forge)
 

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
@@ -201,10 +201,10 @@ class InternalSdkCoreTest : MockServerTest() {
         // Given
         val fakeKeyValues1 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "first_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeKeyValues2 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "second_${anAlphabeticalString()}" to anAlphabeticalString() }
         val expectedKeyValues = fakeKeyValues1 + fakeKeyValues2
 
         val updateAction = { newContext: Map<String, String> ->
@@ -239,10 +239,10 @@ class InternalSdkCoreTest : MockServerTest() {
         // Given
         val fakeKeyValues1 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "first_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeKeyValues2 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "second_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeModifiedValues = fakeKeyValues2.mapValues { (_, _) -> forge.anAlphabeticalString() }
         val expectedKeyValues = fakeKeyValues1 + fakeModifiedValues
 
@@ -288,10 +288,10 @@ class InternalSdkCoreTest : MockServerTest() {
         // Given
         val fakeKeyValues1 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "first_${anAlphabeticalString()}" to anAlphabeticalString() }
         val fakeKeyValues2 = forge.aMap(
             size = forge.anInt(min = 1, max = 10)
-        ) { anAlphabeticalString() to anAlphabeticalString() }
+        ) { "second_${anAlphabeticalString()}" to anAlphabeticalString() }
         val expectedKeyValues = (fakeKeyValues1 + fakeKeyValues2).toMutableMap()
         val droppedKeyValues = expectedKeyValues.removeRandomEntries(forge)
 


### PR DESCRIPTION
### What does this PR do?

Makes the concurrent feature-context integration tests use disjoint key namespaces for each writer. The change is applied consistently to the add, modify, and remove scenarios in both FeatureSdkCoreTest and InternalSdkCoreTest.

### Motivation

The two Forge-generated maps could independently produce the same key. The expected map was built with Kotlin map addition, which deterministically gives precedence to the second map, while the actual updates run concurrently and can validly complete in either order.

For example, both maps generated the key k in the observed failure. The assertion expected the value from the second map, but the first writer acquired the lock last, so its value correctly won. This made the atomicity test fail even though the production locking behavior was correct.

Using first_ and second_ key prefixes removes this accidental same-key conflict so the tests measure atomic updates rather than nondeterministic last-writer-wins behavior.

### Additional Notes

This is a test-only change; production feature-context behavior is unchanged.

Validation:
- reliability core integration-test sources compile
- reliability core ktlint checks pass
- all six affected instrumentation tests pass on an API 37 emulator

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)