### PR TITLE
[FFL-2929] Restore docs ownership for Android Flags README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,6 @@
 ## Feature Flags
 
 /features/dd-sdk-android-flags/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
+/features/dd-sdk-android-flags/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
## Motivation

The Flags directory rule added in #3829 overrides the global README rule. As a result, README changes do not request a documentation review.

## Changes and Decisions

Add a README-specific rule after the Flags directory rule. Retain all existing Flags owners and restore `@DataDog/documentation`.