### PR TITLE
[FFL-2929] Separate Flags implementation ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,13 @@
 
 ## Feature Flags
 
-/features/dd-sdk-android-flags/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
-/features/dd-sdk-android-flags-openfeature/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
+# FFE owns implementation changes. Public API changes also update the API snapshot paths below.
+/features/dd-sdk-android-flags/ @DataDog/feature-flagging-and-experimentation-sdk
+/features/dd-sdk-android-flags-openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
+
+# Mobile SDK and FFE owners review public API changes.
+/features/dd-sdk-android-flags/api/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
+/features/dd-sdk-android-flags-openfeature/api/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
+
+/features/dd-sdk-android-flags/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,5 +17,5 @@
 /features/dd-sdk-android-flags/api/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/api/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 
-/features/dd-sdk-android-flags/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
+/features/dd-sdk-android-flags/README.md @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
## Motivation

FFE owns the Flags implementation. The current rules also require mobile review for internal changes that do not change the SDK public API.

## Changes and Decisions

- Assign the Flags and Flags OpenFeature implementation paths to FFE.
- Keep mobile and FFE ownership on the generated API snapshot paths.
- Preserve the existing effective ownership of both Flags README files.
- Require mobile review when a Flags public API change updates an API snapshot.
- Keep Session Replay unchanged because the mobile team owns its implementation and public API.