### PR TITLE
Discard ANR profile without the upload implementation

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -241,7 +241,10 @@ internal class ProfilingFeature(
         if (isLaunchProfilingActive || continuousProfilingScheduler?.isActive == true) {
             sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(event)
         }
-        pendingTriggerProfiles.addProfilingResult(result)
+        // TODO RUM-18341: route the result through PendingTriggerProfiles for matching and
+        // upload once the buffer is implemented. Until then the trace file would be leaked on
+        // disk, so delete it here.
+        dataWriter.discard(result)
     }
 
     private fun onTtidEvent() {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -1369,7 +1369,7 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
-    fun `M forward profiling result to pendingTriggerProfiles W onAnrDetected()`(
+    fun `M discard ANR profiling result W onAnrDetected()`(
         @Forgery fakeEvent: ProfilingAnrDetectedEvent,
         @Forgery fakeResult: PerfettoResult
     ) {
@@ -1377,13 +1377,13 @@ internal class ProfilingFeatureTest {
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
         whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
-        testedFeature.pendingTriggerProfiles = mockPendingTriggerProfiles
+        testedFeature.dataWriter = mockDataWriter
 
         // When
         testedFeature.onAnrDetected(fakeEvent, fakeResult)
 
         // Then
-        verify(mockPendingTriggerProfiles).addProfilingResult(fakeResult)
+        verify(mockDataWriter).discard(fakeResult)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Fixes a disk leak of ANR profiling trace files. `PendingTriggerProfiles` (the ANR-trigger ↔ RUM-gating-event matcher) is not yet implemented — it's a no-op (tracked by RUM-18341). As a result, `onAnrDetected` was forwarding the `PerfettoResult` (which holds a real trace file on disk) into the no-op buffer, so the file was never deleted or uploaded.

This PR replaces the no-op routing with a direct `dataWriter.discard(result)` call, which deletes the trace file via the existing safe-delete path. A `TODO RUM-18341` marks where the real matching/upload routing should go once the buffer is implemented.

### Motivation

Shipping a release before the `PendingTriggerProfiles` implementation lands. Without this fix, every ANR leaks a Perfetto trace file on disk with no upload path to ever consume it.

### Additional Notes

- No new implementation introduced — reuses the existing `ProfilingWriter.discard` logic.
- Unit test updated to verify the discard happens on `onAnrDetected`.
- Revert to `pendingTriggerProfiles.addProfilingResult(result)` once RUM-18341 ships the real buffer.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)
