### PR TITLE
Use device boot time for profiling duration

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -76,8 +76,13 @@ internal class PerfettoProfiler(
     @Volatile
     private var profilingStartTime = 0L
 
+    // Monotonic (boot-relative) captures used for duration and callback-delay, which must
+    // keep advancing during deep sleep and be immune to wall-clock adjustments.
     @Volatile
-    private var profilingStopTime = 0L
+    private var profilingStartElapsedMs = 0L
+
+    @Volatile
+    private var profilingStopElapsedMs = 0L
 
     @Volatile
     private var profilingStartReason: ProfilingStartReason = ProfilingStartReason.UNKNOWN
@@ -108,14 +113,16 @@ internal class PerfettoProfiler(
 
     init {
         resultCallback = Consumer<ProfilingResult> { result ->
-            val resultCallbackTime = timeProvider.getDeviceElapsedRealtimeMillis()
-            // profilingStopTime is 0L when profiling ended by timeout (stop() was never called).
-            // In that case, fall back to resultCallbackTime so duration is still meaningful.
-            val effectiveStopTime =
-                if (profilingStopTime > 0L) profilingStopTime else resultCallbackTime
-            val duration = effectiveStopTime - profilingStartTime
+            val resultCallbackTime = timeProvider.getDeviceTimestampMillis()
+            val resultCallbackElapsedMs = timeProvider.getDeviceElapsedRealtimeMillis()
+            // profilingStopElapsedMs is 0L when profiling ended by timeout (stop() was never
+            // called). In that case, fall back to the callback elapsed time so duration is
+            // still meaningful.
+            val effectiveStopElapsedMs =
+                if (profilingStopElapsedMs > 0L) profilingStopElapsedMs else resultCallbackElapsedMs
+            val duration = effectiveStopElapsedMs - profilingStartElapsedMs
             val resultCallbackDelayMs =
-                if (profilingStopTime > 0L) resultCallbackTime - profilingStopTime else 0L
+                if (profilingStopElapsedMs > 0L) resultCallbackElapsedMs - profilingStopElapsedMs else 0L
             val startReason = ProfilingStartReason.entries.firstOrNull { it.value == result.tag.orEmpty() }
                 ?: ProfilingStartReason.UNKNOWN
             if (result.errorCode == ProfilingResult.ERROR_NONE) {
@@ -203,8 +210,9 @@ internal class PerfettoProfiler(
         }
         // profiling will be launched when no session is currently running.
         if (isRunning.compareAndSet(false, true)) {
-            profilingStartTime = timeProvider.getDeviceElapsedRealtimeMillis()
-            profilingStopTime = 0L
+            profilingStartTime = timeProvider.getDeviceTimestampMillis()
+            profilingStartElapsedMs = timeProvider.getDeviceElapsedRealtimeMillis()
+            profilingStopElapsedMs = 0L
             profilingStartReason = startReason
             profilingAppStartInfo = additionalAttributes[ProfilingTelemetry.KEY_APP_START_INFO]
             requestProfiling(
@@ -239,7 +247,7 @@ internal class PerfettoProfiler(
             // overwritten by that time. Probably need to allow a single profiler instance and stop profiler before
             // starting another request.
             stopSignal?.cancel()
-            profilingStopTime = timeProvider.getDeviceElapsedRealtimeMillis()
+            profilingStopElapsedMs = timeProvider.getDeviceElapsedRealtimeMillis()
         }
     }
 
@@ -292,7 +300,7 @@ internal class PerfettoProfiler(
     }
 
     private fun resolveStopReason(errorCode: Int): String {
-        return if (profilingStopTime > 0L) {
+        return if (profilingStopElapsedMs > 0L) {
             ProfilingTelemetry.STOPPED_REASON_MANUAL
         } else {
             when (errorCode) {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -108,7 +108,7 @@ internal class PerfettoProfiler(
 
     init {
         resultCallback = Consumer<ProfilingResult> { result ->
-            val resultCallbackTime = timeProvider.getDeviceTimestampMillis()
+            val resultCallbackTime = timeProvider.getDeviceElapsedRealtimeMillis()
             // profilingStopTime is 0L when profiling ended by timeout (stop() was never called).
             // In that case, fall back to resultCallbackTime so duration is still meaningful.
             val effectiveStopTime =
@@ -203,7 +203,7 @@ internal class PerfettoProfiler(
         }
         // profiling will be launched when no session is currently running.
         if (isRunning.compareAndSet(false, true)) {
-            profilingStartTime = timeProvider.getDeviceTimestampMillis()
+            profilingStartTime = timeProvider.getDeviceElapsedRealtimeMillis()
             profilingStopTime = 0L
             profilingStartReason = startReason
             profilingAppStartInfo = additionalAttributes[ProfilingTelemetry.KEY_APP_START_INFO]
@@ -239,7 +239,7 @@ internal class PerfettoProfiler(
             // overwritten by that time. Probably need to allow a single profiler instance and stop profiler before
             // starting another request.
             stopSignal?.cancel()
-            profilingStopTime = timeProvider.getDeviceTimestampMillis()
+            profilingStopTime = timeProvider.getDeviceElapsedRealtimeMillis()
         }
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -1288,15 +1288,17 @@ internal class PerfettoProfilerTest {
         var stopTime: Long = 0L
 
         var resultCallbackTime: Long = 0L
-        private var queryIncrement: Int = 0
+        private var wallQueryIncrement: Int = 0
+        private var elapsedQueryIncrement: Int = 0
 
         fun reset() {
-            queryIncrement = 0
+            wallQueryIncrement = 0
+            elapsedQueryIncrement = 0
         }
 
         override fun getDeviceTimestampMillis(): Long {
-            val current = queryIncrement
-            queryIncrement++
+            val current = wallQueryIncrement
+            wallQueryIncrement++
             return when (current) {
                 0 -> startTime
                 1 -> stopTime
@@ -1312,7 +1314,15 @@ internal class PerfettoProfilerTest {
 
         override fun getServerOffsetMillis(): Long = 0L
 
-        override fun getDeviceElapsedRealtimeMillis(): Long = 0L
+        override fun getDeviceElapsedRealtimeMillis(): Long {
+            val current = elapsedQueryIncrement
+            elapsedQueryIncrement++
+            return when (current) {
+                0 -> startTime
+                1 -> stopTime
+                else -> resultCallbackTime
+            }
+        }
         override fun getDeviceElapsedRealtimeNanos(): Long = 0L
         override fun getDeviceUptimeMillis(): Long = 0L
     }


### PR DESCRIPTION
## What

Switches `PerfettoProfiler` duration measurement from the wall clock (`System.currentTimeMillis`) to the monotonic boot clock (`SystemClock.elapsedRealtime`).

## Motivation

The wall clock does not advance during deep sleep and can be adjusted by the user or NITZ, leading to inaccurate profile durations. The boot clock keeps running during sleep and is immune to wall-clock changes, giving a more precise duration.
