### PR TITLE
Send profile duration telemetry in nanoseconds

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetry.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetry.kt
@@ -8,6 +8,7 @@ package com.datadog.android.profiling.internal.telemetry
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.metrics.MethodCallSamplingRate
+import java.util.concurrent.TimeUnit
 
 internal class ProfilingTelemetry {
 
@@ -66,7 +67,7 @@ internal class ProfilingTelemetry {
                 KEY_PROFILING_SESSION to mapOf(
                     KEY_ERROR_CODE to event.errorCode,
                     KEY_START_REASON to event.startReason,
-                    KEY_DURATION to event.durationMs,
+                    KEY_DURATION to TimeUnit.MILLISECONDS.toNanos(event.durationMs),
                     KEY_CALLBACK_DELAY to event.resultCallbackDelayMs,
                     KEY_CLIENT_CLOCK_DRIFT to event.clientClockDriftMs,
                     KEY_ERROR_MESSAGE to event.errorMessage,

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -185,7 +185,7 @@ internal class PerfettoProfilerTest {
     fun `M send telemetry W profiling finishes {with timeout}`(
         @StringForgery fakeErrorMessage: String,
         @LongForgery(min = 0L) fakeStartTime: Long,
-        @LongForgery(min = 0L) fakeDuration: Long
+        @LongForgery(min = 0L, max = Int.MAX_VALUE.toLong()) fakeDuration: Long
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
@@ -221,7 +221,7 @@ internal class PerfettoProfilerTest {
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "error_message" to fakeErrorMessage,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
-                "duration" to fakeDuration,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeDuration),
                 "callback_delay_ms" to 0L,
                 "client_clock_drift_ms" to 0L,
                 "file_size" to 0L,
@@ -249,7 +249,7 @@ internal class PerfettoProfilerTest {
     fun `M send telemetry W profiling finishes {with error}`(
         @StringForgery fakeErrorMessage: String,
         @LongForgery(min = 0L) fakeStartTime: Long,
-        @LongForgery(min = 0L) fakeDuration: Long,
+        @LongForgery(min = 0L, max = Int.MAX_VALUE.toLong()) fakeDuration: Long,
         @IntForgery(min = 1, max = 8) fakeErrorCode: Int
     ) {
         // Given
@@ -284,7 +284,7 @@ internal class PerfettoProfilerTest {
             "profiling_session" to mapOf(
                 "error_code" to fakeErrorCode,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
-                "duration" to fakeDuration,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeDuration),
                 "callback_delay_ms" to 0L,
                 "client_clock_drift_ms" to 0L,
                 "error_message" to fakeErrorMessage,
@@ -313,7 +313,7 @@ internal class PerfettoProfilerTest {
     fun `M send metric telemetry W internalLogger is assigned later`(
         @StringForgery fakeErrorMessage: String,
         @LongForgery(min = 0L) fakeStartTime: Long,
-        @LongForgery(min = 0L) fakeDuration: Long
+        @LongForgery(min = 0L, max = Int.MAX_VALUE.toLong()) fakeDuration: Long
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
@@ -349,7 +349,7 @@ internal class PerfettoProfilerTest {
             "profiling_session" to mapOf(
                 "error_code" to ProfilingResult.ERROR_FAILED_PROFILING_IN_PROGRESS,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
-                "duration" to fakeDuration,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeDuration),
                 "callback_delay_ms" to 0L,
                 "client_clock_drift_ms" to 0L,
                 "error_message" to fakeErrorMessage,
@@ -663,7 +663,7 @@ internal class PerfettoProfilerTest {
     fun `M include app_start_info in telemetry W profiling finishes { additionalAttributes contains app_start_info }`(
         @StringForgery fakeAppStartInfo: String,
         @LongForgery(min = 0L) fakeStartTime: Long,
-        @LongForgery(min = 0L) fakeDuration: Long
+        @LongForgery(min = 0L, max = Int.MAX_VALUE.toLong()) fakeDuration: Long
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
@@ -699,7 +699,7 @@ internal class PerfettoProfilerTest {
             "profiling_session" to mapOf(
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
-                "duration" to fakeDuration,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeDuration),
                 "callback_delay_ms" to 0L,
                 "client_clock_drift_ms" to 0L,
                 "error_message" to null,
@@ -728,7 +728,7 @@ internal class PerfettoProfilerTest {
     fun `M include start_reason in telemetry W profiling finishes { startReason }`(
         startReason: ProfilingStartReason,
         @LongForgery(min = 0L) fakeStartTime: Long,
-        @LongForgery(min = 0L) fakeDuration: Long
+        @LongForgery(min = 0L, max = Int.MAX_VALUE.toLong()) fakeDuration: Long
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
@@ -765,7 +765,7 @@ internal class PerfettoProfilerTest {
             "profiling_session" to mapOf(
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "start_reason" to startReason.value,
-                "duration" to fakeDuration,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeDuration),
                 "callback_delay_ms" to 0L,
                 "client_clock_drift_ms" to 0L,
                 "error_message" to null,
@@ -834,7 +834,7 @@ internal class PerfettoProfilerTest {
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "error_message" to fakeErrorMessage,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
-                "duration" to fakeStopDelta,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeStopDelta),
                 "callback_delay_ms" to fakeCallbackDelta,
                 "client_clock_drift_ms" to 0L,
                 "file_size" to 0L,
@@ -927,7 +927,7 @@ internal class PerfettoProfilerTest {
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "error_message" to null,
                 "start_reason" to ProfilingStartReason.CONTINUOUS.value,
-                "duration" to fakeDuration2,
+                "duration" to TimeUnit.MILLISECONDS.toNanos(fakeDuration2),
                 "callback_delay_ms" to 0L,
                 "client_clock_drift_ms" to 0L,
                 "file_size" to 0L,

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryTest.kt
@@ -30,6 +30,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.quality.Strictness
+import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -56,7 +57,7 @@ internal class ProfilingTelemetryTest {
     @Test
     fun `M dispatch SessionEnd through logMetric W report() {logger set}`(
         @StringForgery fakeErrorMessage: String,
-        @LongForgery(min = 0L) fakeDuration: Long,
+        @LongForgery(min = 0L, max = Int.MAX_VALUE.toLong()) fakeDuration: Long,
         @LongForgery fakeClientClockDriftMs: Long,
         @IntForgery(min = 1, max = 8) fakeErrorCode: Int
     ) {
@@ -86,7 +87,7 @@ internal class ProfilingTelemetryTest {
             ProfilingTelemetry.KEY_PROFILING_SESSION to mapOf(
                 ProfilingTelemetry.KEY_ERROR_CODE to fakeErrorCode,
                 ProfilingTelemetry.KEY_START_REASON to ProfilingStartReason.APPLICATION_LAUNCH.value,
-                ProfilingTelemetry.KEY_DURATION to fakeDuration,
+                ProfilingTelemetry.KEY_DURATION to TimeUnit.MILLISECONDS.toNanos(fakeDuration),
                 ProfilingTelemetry.KEY_CALLBACK_DELAY to 0L,
                 ProfilingTelemetry.KEY_CLIENT_CLOCK_DRIFT to fakeClientClockDriftMs,
                 ProfilingTelemetry.KEY_ERROR_MESSAGE to fakeErrorMessage,


### PR DESCRIPTION
### What does this PR do?

This change is to align with profiling telemetry spec, duration is in nanoseconds there.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

