### PR TITLE
RUM-18032: Expose setRemoteConfigurationId as public API

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -38,7 +38,6 @@ class com.datadog.android._InternalProxy
   fun flushAndShutdownExecutors()
   companion object 
     fun allowClearTextHttp(com.datadog.android.core.configuration.Configuration.Builder): com.datadog.android.core.configuration.Configuration.Builder
-    fun setRemoteConfigurationId(com.datadog.android.core.configuration.Configuration.Builder, String): com.datadog.android.core.configuration.Configuration.Builder
 interface com.datadog.android.api.InternalLogger
   enum Level
     - VERBOSE
@@ -290,6 +289,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun setBackpressureStrategy(BackPressureStrategy): Builder
     fun setUploadSchedulerStrategy(UploadSchedulerStrategy?): Builder
     fun setVersion(String): Builder
+    fun setRemoteConfigurationId(String): Builder
   companion object 
 class com.datadog.android.core.configuration.HostPatternSanitizer
   constructor(com.datadog.android.api.InternalLogger)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -84,7 +84,6 @@ public final class com/datadog/android/_InternalProxy {
 
 public final class com/datadog/android/_InternalProxy$Companion {
 	public final fun allowClearTextHttp (Lcom/datadog/android/core/configuration/Configuration$Builder;)Lcom/datadog/android/core/configuration/Configuration$Builder;
-	public final fun setRemoteConfigurationId (Lcom/datadog/android/core/configuration/Configuration$Builder;Ljava/lang/String;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 }
 
 public final class com/datadog/android/_InternalProxy$_TelemetryProxy {
@@ -785,6 +784,7 @@ public final class com/datadog/android/core/configuration/Configuration$Builder 
 	public final fun setFirstPartyHostsWithHeaderType (Ljava/util/Map;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setPersistenceStrategyFactory (Lcom/datadog/android/core/persistence/PersistenceStrategy$Factory;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setProxy (Ljava/net/Proxy;Lokhttp3/Authenticator;)Lcom/datadog/android/core/configuration/Configuration$Builder;
+	public final fun setRemoteConfigurationId (Ljava/lang/String;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadFrequency (Lcom/datadog/android/core/configuration/UploadFrequency;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadSchedulerStrategy (Lcom/datadog/android/core/configuration/UploadSchedulerStrategy;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUseDeveloperModeWhenDebuggable (Z)Lcom/datadog/android/core/configuration/Configuration$Builder;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/_InternalProxy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/_InternalProxy.kt
@@ -98,12 +98,5 @@ class _InternalProxy internal constructor(
         fun allowClearTextHttp(builder: Configuration.Builder): Configuration.Builder {
             return builder.allowClearTextHttp()
         }
-
-        fun setRemoteConfigurationId(
-            builder: Configuration.Builder,
-            remoteConfigurationId: String
-        ): Configuration.Builder {
-            return builder.setRemoteConfigurationId(remoteConfigurationId)
-        }
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -301,7 +301,13 @@ internal constructor(
             return this
         }
 
-        internal fun setRemoteConfigurationId(remoteConfigurationId: String): Builder {
+        /**
+         * Sets the remote configuration ID used to fetch SDK settings from the Datadog CDN.
+         *
+         * @param remoteConfigurationId the opaque identifier assigned during application
+         * onboarding in the Datadog UI.
+         */
+        fun setRemoteConfigurationId(remoteConfigurationId: String): Builder {
             coreConfig = coreConfig.copy(remoteConfigurationId = remoteConfigurationId)
             return this
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -15,7 +15,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
-import com.datadog.android._InternalProxy
 import com.datadog.android.compose.enableComposeActionTracking
 import com.datadog.android.core.configuration.BackPressureMitigation
 import com.datadog.android.core.configuration.BackPressureStrategy
@@ -449,7 +448,7 @@ class SampleApplication : Application() {
             .setUploadFrequency(UploadFrequency.FREQUENT)
             .apply {
                 if (BuildConfig.DD_REMOTE_CONFIGURATION_ID.isNotBlank()) {
-                    _InternalProxy.setRemoteConfigurationId(this, BuildConfig.DD_REMOTE_CONFIGURATION_ID)
+                    setRemoteConfigurationId(BuildConfig.DD_REMOTE_CONFIGURATION_ID)
                 }
             }
 


### PR DESCRIPTION
### What does this PR do?
Makes `Configuration.Builder.setRemoteConfigurationId(String)` public again and removes the corresponding `_InternalProxy.setRemoteConfigurationId(...)` proxy method, updating the sample app to call the builder method directly.

### Motivation
Make Remote Configuration publicly accessible through the `Configuration.Builder` API.

### Additional Notes
- **API surface change**: adds `Configuration.Builder.setRemoteConfigurationId(String): Builder` back to the public API (`dd-sdk-android-core.api` / `apiSurface`), and removes `_InternalProxy.Companion.setRemoteConfigurationId(...)`. This is a pure reversal of the change introduced by RUM-18032 in #3733 — no other behavior changes.
- No test changes needed: `ConfigurationBuilderTest` already exercised the builder method directly and continues to pass.
- Verified: targeted unit tests, sample app compilation (`:sample:kotlin:compileUs1DebugKotlin`), and full local pre-commit checks (lintRelease, detekt ×2, ktlint, detekt public-api, full test suite) all passed.

cc: @maxep 

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)