### PR TITLE
Fix dd-octo-sts permission typo

### DIFF
--- a/.github/chainguard/self.gitlab.release.create-release.sts.yaml
+++ b/.github/chainguard/self.gitlab.release.create-release.sts.yaml
@@ -10,4 +10,4 @@ claim_pattern:
 
 permissions:
   contents: write
-  pull-requests: write
+  pull_requests: write


### PR DESCRIPTION
[`notify-github-release`](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/2029081875) job is failing in the 3.14.0 tag pipeline. This typo was introduced after the 3.13.0 release so went unnoticed. After merging this to `develop`, we should be able to retrigger the failing job and make it work, as it reads the policy from the default branch (develop).

[Core Concepts: Trust Policies and Pools](https://datadoghq.atlassian.net/wiki/x/5gDSpgE) document with `pull_requests`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

