### PR TITLE
RUM-17639: Configure merge-back Git identity before merge

### DIFF
--- a/ci/scripts/merge-release-develop.sh
+++ b/ci/scripts/merge-release-develop.sh
@@ -84,6 +84,12 @@ else
   cd "$worktree_dir"
 fi
 
+if [ -n "${CI:-}" ]; then
+  # git merge requires a committer identity before it starts, even with --no-commit.
+  git config user.name "dd-octo-sts"
+  git config user.email "dd-octo-sts@datadoghq.com"
+fi
+
 echo "Merging develop into a local copy of tag $tag..."
 set +e
 merge_output=$(git merge origin/develop --no-commit --no-ff 2>&1)
@@ -105,10 +111,9 @@ fi
 
 conflicting_files=$(git diff --name-only --diff-filter=U)
 if [ -z "$conflicting_files" ]; then
-  # Merge failed but left no conflict markers to resolve - not the routine
-  # version-file conflict, something else went wrong. Fail loudly instead
-  # of silently treating it as resolved.
-  git merge --abort
+  # Merge failed without producing conflicts. Clean up if Git started a merge,
+  # but preserve the original failure when there is no merge state to abort.
+  git merge --abort 2>/dev/null || true
   echo "Merge failed without leaving any conflicts to resolve, aborting:" >&2
   echo "$merge_output" >&2
   exit 1
@@ -139,12 +144,6 @@ echo "Keeping develop's version in $version_file"
 # whole file is exactly what we want here.
 git checkout --theirs "$version_file"
 git add "$version_file"
-
-if [ -n "${CI:-}" ]; then
-  # CI has no git identity configured by default.
-  git config user.name "dd-octo-sts"
-  git config user.email "dd-octo-sts@datadoghq.com"
-fi
 
 git commit -m "Merge branch 'develop' into '$branch_name'"
 


### PR DESCRIPTION
### What does this PR do?

Configures the CI Git committer identity before the release merge-back script invokes `git merge`. It also prevents a failed `git merge --abort` cleanup from masking the original merge error when no merge was started.

### Motivation

The `post-release:merge-develop` job for 3.14.0 failed because `git merge --no-commit --no-ff` validates the committer identity before starting the merge, while the script configured that identity only immediately before `git commit`.

### Additional Notes

Validation performed:

- `bash -n ci/scripts/merge-release-develop.sh`
- `git diff --check`
- Isolated CI-mode dry-run against tag `3.14.0` and current `develop`, with GitHub push and PR creation stubbed. The script resolved the expected version conflict, created the merge commit as `dd-octo-sts <dd-octo-sts@datadoghq.com>`, and reached both external-operation stubs with no unresolved conflicts.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)