### PR TITLE
RUMS-6337: Cap body-peek size and skip it for binary media

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -153,8 +153,10 @@ object com.datadog.android.internal.network.HttpSpec
     const val APPLICATION_GRPC: String
     const val APPLICATION_GRPC_PROTO: String
     const val APPLICATION_GRPC_JSON: String
+    const val APPLICATION_OCTET_STREAM: String
     fun values()
     fun isStream(String?): Boolean
+    fun isBinaryMedia(String?): Boolean
 interface com.datadog.android.internal.profiler.BenchmarkCounter
   fun add(Long, Map<String, String>)
 interface com.datadog.android.internal.profiler.BenchmarkMeter

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -239,9 +239,11 @@ public final class com/datadog/android/internal/network/HttpSpec$ContentType {
 	public static final field APPLICATION_GRPC_JSON Ljava/lang/String;
 	public static final field APPLICATION_GRPC_PROTO Ljava/lang/String;
 	public static final field APPLICATION_JSON Ljava/lang/String;
+	public static final field APPLICATION_OCTET_STREAM Ljava/lang/String;
 	public static final field INSTANCE Lcom/datadog/android/internal/network/HttpSpec$ContentType;
 	public static final field TEXT_EVENT_STREAM Ljava/lang/String;
 	public static final field TEXT_PLAIN Ljava/lang/String;
+	public final fun isBinaryMedia (Ljava/lang/String;)Z
 	public final fun isStream (Ljava/lang/String;)Z
 	public final fun values ()Ljava/util/List;
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/HttpSpec.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/HttpSpec.kt
@@ -213,6 +213,9 @@ object HttpSpec {
         /** gRPC with JSON content type. */
         const val APPLICATION_GRPC_JSON: String = "application/grpc+json"
 
+        /** Generic/opaque binary payload content type. */
+        const val APPLICATION_OCTET_STREAM: String = "application/octet-stream"
+
         /**
          * Returns a list of all content type values.
          */
@@ -222,7 +225,8 @@ object HttpSpec {
             TEXT_EVENT_STREAM,
             APPLICATION_GRPC,
             APPLICATION_GRPC_PROTO,
-            APPLICATION_GRPC_JSON
+            APPLICATION_GRPC_JSON,
+            APPLICATION_OCTET_STREAM
         )
 
         /**
@@ -234,11 +238,24 @@ object HttpSpec {
             return contentType != null && contentType in STREAM_CONTENT_TYPES
         }
 
+        /**
+         * Checks if the given content type is binary media (image/video/audio/octet-stream) —
+         * large, opaque payloads with no useful signal to justify buffering.
+         * @param contentType the content type to check
+         * @return true if the content type is binary media, false otherwise
+         */
+        fun isBinaryMedia(contentType: String?): Boolean {
+            if (contentType == null) return false
+            return contentType == APPLICATION_OCTET_STREAM || BINARY_MEDIA_PREFIXES.any { contentType.startsWith(it) }
+        }
+
         private val STREAM_CONTENT_TYPES = setOf(
             TEXT_EVENT_STREAM,
             APPLICATION_GRPC,
             APPLICATION_GRPC_PROTO,
             APPLICATION_GRPC_JSON
         )
+
+        private val BINARY_MEDIA_PREFIXES = setOf("image/", "video/", "audio/")
     }
 }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -304,8 +304,13 @@ open class DatadogInterceptor internal constructor(
             // if there is a Content-Length available, we can read it directly
             // however, OkHttp will drop Content-Length header if transparent compression is
             // used (since the value reported cannot be applied to decompressed body), so to be
-            // able to still read it, we force decompression by calling peekBody
-            body.contentLengthOrNull() ?: response.peekBody(MAX_BODY_PEEK).contentLengthOrNull()
+            // able to still read it, we force decompression by calling peekBody - unless this is
+            // binary media (image/video/audio/octet-stream), which is large and not worth buffering
+            body.contentLengthOrNull() ?: if (HttpSpec.ContentType.isBinaryMedia(contentType)) {
+                null
+            } else {
+                response.peekBody(MAX_BODY_PEEK).contentLengthOrNull()
+            }
         } catch (e: IOException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -466,7 +471,7 @@ open class DatadogInterceptor internal constructor(
         internal const val ORIGIN_RUM = "rum"
 
         // We need to limit this value as the body will be loaded in memory
-        private const val MAX_BODY_PEEK: Long = 32 * 1024L * 1024L
+        private const val MAX_BODY_PEEK: Long = 512L * 1024L
 
         private const val ALL_IN_SAMPLE_RATE: Float = 100f
         private const val ZERO_SAMPLE_RATE: Float = 0f

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/OkHttpResponseInfo.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/OkHttpResponseInfo.kt
@@ -9,6 +9,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.api.instrumentation.network.HttpResponseInfo
+import com.datadog.android.internal.network.HttpSpec
 import okhttp3.Response
 import okhttp3.ResponseBody
 import java.io.IOException
@@ -33,12 +34,21 @@ internal class OkHttpResponseInfo(
     @get:WorkerThread
     override val contentLength: Long?
         get() = try {
-            // if there is a Content-Length available, we can read it directly
-            // however, OkHttp will drop Content-Length header if transparent compression is
-            // used (since the value reported cannot be applied to decompressed body), so to be
-            // able to still read it, we force decompression by calling peekBody
-            originalResponse.body?.contentLengthOrNull()
-                ?: originalResponse.peekBody(MAX_BODY_PEEK_BYTES).contentLengthOrNull()
+            if (HttpSpec.ContentType.isStream(contentType)) {
+                null
+            } else {
+                // if there is a Content-Length available, we can read it directly
+                // however, OkHttp will drop Content-Length header if transparent compression is
+                // used (since the value reported cannot be applied to decompressed body), so to be
+                // able to still read it, we force decompression by calling peekBody - unless this
+                // is binary media (image/video/audio/octet-stream), which is large and not worth
+                // buffering
+                originalResponse.body?.contentLengthOrNull() ?: if (HttpSpec.ContentType.isBinaryMedia(contentType)) {
+                    null
+                } else {
+                    originalResponse.peekBody(MAX_BODY_PEEK_BYTES).contentLengthOrNull()
+                }
+            }
         } catch (e: IOException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -71,7 +81,7 @@ internal class OkHttpResponseInfo(
     internal companion object {
 
         // We need to limit this value as the body will be loaded in memory
-        private const val MAX_BODY_PEEK_BYTES: Long = 32 * 1024L * 1024L
+        private const val MAX_BODY_PEEK_BYTES: Long = 512L * 1024L
 
         internal const val ERROR_PEEK_BODY = "Unable to peek response body."
 


### PR DESCRIPTION
### What does this PR do?

Lowers `MAX_BODY_PEEK`/`MAX_BODY_PEEK_BYTES` from 32 MB to 512 KB in `DatadogInterceptor.getBodyLength()` and `OkHttpResponseInfo.contentLength`, aligning with the cap [dd-sdk-ios#3019](https://github.com/DataDog/dd-sdk-ios/pull/3019) uses for the same class of problem. Also skips `peekBody()` entirely for binary media (`image/*`, `video/*`, `audio/*`, `application/octet-stream`) once no `Content-Length` is already known, mirroring iOS's exclusion for the same reason.

### Motivation

Both paths call OkHttp's `peekBody()` to recover `Content-Length` when a response is missing it (transparent compression / chunked encoding). A 32 MB single allocation, unconditionally, on every such response was flagged as a plausible contributor to an OOM escalation ([RUMS-6337](https://datadoghq.atlassian.net/browse/RUMS-6337)) on a device with a constrained 256 MB heap running several other SDKs. iOS hit the same class of issue and fixed it with a 512 KB cap plus a binary-media exclusion; this brings Android in line.

### Additional Notes

Responses larger than 512 KB and missing `Content-Length` will now report a size of exactly 512 KB (or `null` for excluded binary media) instead of the true size - a known data-quality trade-off, accepted here in favor of memory safety.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RUMS-6337]: https://datadoghq.atlassian.net/browse/RUMS-6337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ